### PR TITLE
Bags remain active when killing record_bag with monitoring UI

### DIFF
--- a/rosmon_core/src/launch/launch_config.cpp
+++ b/rosmon_core/src/launch/launch_config.cpp
@@ -425,10 +425,10 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext ctx)
 		node->setRespawnDelay(ros::WallDuration(seconds));
 	}
         
-        if(shutdownHandler)
-        {
+	if(shutdownHandler)
+	{
 		node->setShutdownHandler(shutdownHandler);
-        }
+	}
 
 	if(required && ctx.parseBool(required, element->Row()))
 	{

--- a/rosmon_core/src/launch/launch_config.cpp
+++ b/rosmon_core/src/launch/launch_config.cpp
@@ -427,7 +427,7 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext ctx)
         
 	if(shutdownHandler)
 	{
-		node->setShutdownHandler(shutdownHandler);
+		node->setShutdownHandler(ctx.evaluate(shutdownHandler));
 	}
 
 	if(required && ctx.parseBool(required, element->Row()))

--- a/rosmon_core/src/launch/launch_config.cpp
+++ b/rosmon_core/src/launch/launch_config.cpp
@@ -298,6 +298,7 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext ctx)
 	const char* stopTimeout = element->Attribute("rosmon-stop-timeout");
     const char* memoryLimit = element->Attribute("rosmon-memory-limit");
     const char* cpuLimit = element->Attribute("rosmon-cpu-limit");
+    const char* shutdownHandler = element->Attribute("shutdown-handler");
 
 
 	if(!name || !pkg || !type)
@@ -423,6 +424,11 @@ void LaunchConfig::parseNode(TiXmlElement* element, ParseContext ctx)
 
 		node->setRespawnDelay(ros::WallDuration(seconds));
 	}
+        
+        if(shutdownHandler)
+        {
+		node->setShutdownHandler(shutdownHandler);
+        }
 
 	if(required && ctx.parseBool(required, element->Row()))
 	{

--- a/rosmon_core/src/launch/node.cpp
+++ b/rosmon_core/src/launch/node.cpp
@@ -100,6 +100,11 @@ void Node::setRespawnDelay(const ros::WallDuration& respawnDelay)
 	m_respawnDelay = respawnDelay;
 }
 
+void Node::setShutdownHandler(const std::string& handler)
+{
+    m_shutdownHandler = handler;
+}
+
 void Node::setLaunchPrefix(const std::string& launchPrefix)
 {
 	wordexp_t tokens;

--- a/rosmon_core/src/launch/node.cpp
+++ b/rosmon_core/src/launch/node.cpp
@@ -102,7 +102,7 @@ void Node::setRespawnDelay(const ros::WallDuration& respawnDelay)
 
 void Node::setShutdownHandler(const std::string& handler)
 {
-    m_shutdownHandler = handler;
+	m_shutdownHandler = handler;
 }
 
 void Node::setLaunchPrefix(const std::string& launchPrefix)

--- a/rosmon_core/src/launch/node.h
+++ b/rosmon_core/src/launch/node.h
@@ -33,6 +33,8 @@ public:
 
 	void setRespawn(bool respawn);
 	void setRespawnDelay(const ros::WallDuration& respawnDelay);
+        
+        void setShutdownHandler(const std::string& handler);
 
 	void setLaunchPrefix(const std::string& launchPrefix);
 
@@ -75,6 +77,9 @@ public:
 
 	ros::WallDuration respawnDelay() const
 	{ return m_respawnDelay; }
+        
+        std::string shutdownHandler() const
+        { return m_shutdownHandler; }
 
 	void setRequired(bool required);
 
@@ -117,6 +122,8 @@ private:
 
 	bool m_respawn;
 	ros::WallDuration m_respawnDelay;
+        
+        std::string m_shutdownHandler;
 
 	bool m_required;
 

--- a/rosmon_core/src/launch/node.h
+++ b/rosmon_core/src/launch/node.h
@@ -34,7 +34,7 @@ public:
 	void setRespawn(bool respawn);
 	void setRespawnDelay(const ros::WallDuration& respawnDelay);
         
-        void setShutdownHandler(const std::string& handler);
+	void setShutdownHandler(const std::string& handler);
 
 	void setLaunchPrefix(const std::string& launchPrefix);
 
@@ -78,8 +78,8 @@ public:
 	ros::WallDuration respawnDelay() const
 	{ return m_respawnDelay; }
         
-        std::string shutdownHandler() const
-        { return m_shutdownHandler; }
+	std::string shutdownHandler() const
+	{ return m_shutdownHandler; }
 
 	void setRequired(bool required);
 
@@ -123,7 +123,7 @@ private:
 	bool m_respawn;
 	ros::WallDuration m_respawnDelay;
         
-        std::string m_shutdownHandler;
+	std::string m_shutdownHandler;
 
 	bool m_required;
 

--- a/rosmon_core/src/monitor/node_monitor.cpp
+++ b/rosmon_core/src/monitor/node_monitor.cpp
@@ -336,8 +336,9 @@ void NodeMonitor::shutdown()
 {
 	if(m_pid != -1)
 	{
-		if (!m_launchNode->shutdownHandler().empty()) {
-                        logTyped(LogEvent::Type::Info, "Handler: {}", m_launchNode->shutdownHandler());
+		if (!m_launchNode->shutdownHandler().empty()) 
+		{
+			logTyped(LogEvent::Type::Info, "Handler: {}", m_launchNode->shutdownHandler());
 			ROS_INFO("Handler: %s", m_launchNode->shutdownHandler().c_str());
 			system(m_launchNode->shutdownHandler().c_str());
 		}

--- a/rosmon_core/src/monitor/node_monitor.cpp
+++ b/rosmon_core/src/monitor/node_monitor.cpp
@@ -341,6 +341,10 @@ void NodeMonitor::shutdown()
 			logTyped(LogEvent::Type::Info, "Handler: {}", m_launchNode->shutdownHandler());
 			ROS_INFO("Handler: %s", m_launchNode->shutdownHandler().c_str());
 			int error = system(m_launchNode->shutdownHandler().c_str());
+			if (error) {
+				logTyped(LogEvent::Type::Error, "Handler returned error");
+				ROS_ERROR("Handler returned error");
+			}
 		}
 		kill(-m_pid, SIGINT);
 	}

--- a/rosmon_core/src/monitor/node_monitor.cpp
+++ b/rosmon_core/src/monitor/node_monitor.cpp
@@ -340,7 +340,7 @@ void NodeMonitor::shutdown()
 		{
 			logTyped(LogEvent::Type::Info, "Handler: {}", m_launchNode->shutdownHandler());
 			ROS_INFO("Handler: %s", m_launchNode->shutdownHandler().c_str());
-			system(m_launchNode->shutdownHandler().c_str());
+			int error = system(m_launchNode->shutdownHandler().c_str());
 		}
 		kill(-m_pid, SIGINT);
 	}

--- a/rosmon_core/src/monitor/node_monitor.cpp
+++ b/rosmon_core/src/monitor/node_monitor.cpp
@@ -336,6 +336,11 @@ void NodeMonitor::shutdown()
 {
 	if(m_pid != -1)
 	{
+		if (!m_launchNode->shutdownHandler().empty()) {
+                        logTyped(LogEvent::Type::Info, "Handler: {}", m_launchNode->shutdownHandler());
+			ROS_INFO("Handler: %s", m_launchNode->shutdownHandler().c_str());
+			system(m_launchNode->shutdownHandler().c_str());
+		}
 		kill(-m_pid, SIGINT);
 	}
 }


### PR DESCRIPTION
Often, when killing record_bag using monitoring UI after it has been killed and restarted by archiving node, the bag remains active. Using rosnode kill before shutting down the launch group kills the rosbag cleanly. 
https://www.wrike.com/open.htm?id=508280504